### PR TITLE
Fix contact form email handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # alexlaurence.github.io
 🏠My home page
+
+## Contact form
+
+The contact form posts to `php/mailsender.php`. To keep the destination email
+address private, set the environment variable `CONTACT_EMAIL` on your server to
+the address that should receive submitted messages (for example
+`alexanderadam.laurence@gmail.com`). When the form is submitted a short
+confirmation message is displayed on the page if the email was accepted.

--- a/php/mailsender.php
+++ b/php/mailsender.php
@@ -1,6 +1,18 @@
 <?php
 
-	$emailTo = "a.laurence@celestial.tokyo"; // Enter your email for feedbacks here 
+// Return JSON responses
+header('Content-Type: application/json');
+
+        // The destination email is provided via environment variable so that it
+        // is not exposed in the repository.  Set CONTACT_EMAIL in the hosting
+        // environment to the address that should receive contact form
+        // submissions.
+        $emailTo = getenv('CONTACT_EMAIL');
+        if (!$emailTo) {
+                // Abort if the variable is not configured.
+                echo json_encode(false);
+                return;
+        }
 	
 	$headers = "MIME-Version: 1.0\r\n";
 	$headers .= "Content-type: text/html; charset=utf-8\r\n";


### PR DESCRIPTION
## Summary
- keep recipient email private in PHP contact form
- document how to set the recipient email

## Testing
- `php -l php/mailsender.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f90ed2cac8329a686331f91e09222