### PR TITLE
Fix contact form email handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # alexlaurence.github.io
 🏠My home page
+
+## Contact form
+
+The contact form posts to `php/mailsender.php`. To keep the destination email
+address private, set the environment variable `CONTACT_EMAIL` on your server to
+the address that should receive submitted messages (for example
+`alexanderadam.laurence@gmail.com`). When the form is submitted a short
+confirmation message is displayed on the page if the email was accepted.

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -1199,25 +1199,30 @@ $(function() {
 		// Reset form errocrt
 		crtFormFields.removeClass('error');
 		crtFormErrocrt = false;
+                crtForm.find('.error-message').remove();
 
 		// Validate form fields	
 		if(!crtFormName.val()) {
 			crtFormErrocrt = true;
 			crtFormName.parent().addClass('error');
+                        crtFormName.after('<span class="error-message">Please enter your name.</span>');
 		}
 		if(!crtFormPrivacy.prop('checked')) {
 			crtFormErrocrt = true;
 			crtFormPrivacy.parent().addClass('error');
+                        crtFormPrivacy.parent().append('<span class="error-message">Please accept the privacy policy.</span>');
 		}
 		
 		if(!crtFormEmail.val() || !isValidEmail(crtFormEmail.val())) {
 			crtFormErrocrt = true;
 			crtFormEmail.parent().addClass('error');
+                        crtFormEmail.after('<span class="error-message">Please enter a valid email.</span>');
 		}
 		
 		if(!crtFormMessage.val()) {
 			crtFormErrocrt = true;
 			crtFormMessage.parent().addClass('error');
+                        crtFormMessage.after('<span class="error-message">Message cannot be empty.</span>');
 		}
 								
 		if(crtFormErrocrt) {
@@ -1229,10 +1234,11 @@ $(function() {
 					function (response) {
 						var data = jQuery.parseJSON( response );
 						if(data){								
-							crtForm.append('<div class="crtFormResponce"><strong>Congratulation!</strong><br>Your email was sent successfully!</div>');
-						} else {
-							crtForm.append('<div class="crtFormResponce"><strong>OOPS!</strong> Something went wrong.<br>Please try again.</div>');
+                                                        window.location.href = 'message-sent.html';
 						}							
+                                                else {
+                                                        crtForm.append('<div class="crtFormResponce"><strong>OOPS!</strong> Something went wrong.<br>Please try again.</div>');
+                                                }
 					}
 				);
 			return false;

--- a/message-sent.html
+++ b/message-sent.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <title>Alexander Laurence | Contact</title>
+    <title>Alexander Laurence | Message Sent</title>
     <meta name="description" content="">
 
     <link rel="apple-touch-icon" href="apple-touch-icon.png">
@@ -21,7 +21,6 @@
     <!-- Styles -->
     <link href="assets/css/plugins.min.css" rel="stylesheet">
     <link href="assets/css/style.min.css" rel="stylesheet">
-    <style>.error-message{color:#fa958b;font-size:0.8em;margin-top:4px;display:block;}</style>
 
     <!-- Modernizer -->
     <script type="text/javascript" src="assets/js/vendor/modernizr-3.3.1.min.js"></script>
@@ -217,52 +216,10 @@
                             </header>
                         </div>
 
-                        <div class="padd-box-sm">
-                            <form action="php/mailsender.php" method="post" class="contact-form">
-
-                                <div class="form-group">
-                                    <label class="form-label" for="author">Your Name</label>
-
-                                    <div class="form-item-wrap">
-                                        <input id="author" class="form-item" name="crtName" type="text">
-                                    </div>
-                                </div>
-
-                                <div class="form-group">
-                                    <label class="form-label" for="email">Your E-mail</label>
-
-                                    <div class="form-item-wrap">
-                                        <input id="email" class="form-item" type="email" name="crtEmail" required="required">
-                                    </div>
-                                </div>
-
-                                <div class="form-group">
-                                    <label class="form-label" for="url">Subject</label>
-
-                                    <div class="form-item-wrap">
-                                        <input id="url" class="form-item" type="url" name="crtSubject">
-                                    </div>
-                                </div>
-
-                                <div class="form-group">
-                                    <label class="form-label" for="comment">Your Comment</label>
-
-                                    <div class="form-item-wrap">
-                                        <textarea id="comment" class="form-item" name="crtMessage"></textarea>
-                                    </div>
-                                </div>
-								
-								<div class="form-group">
-									<div class="form-item-wrap check-field">
-										<input type="checkbox" name="crtPivacyPolicy" id="crtPivacyPolicyWidget">
-										<label for="crtPivacyPolicy">I have read the Privacy Policy note.</label>
-									</div>
-								</div>
-
-                                <div class="form-submit form-item-wrap">
-                                    <input class="btn btn-primary btn-lg crtFormSubmit" type="submit" value="Post Your Comment">
-                                </div>
-                            </form>
+                            <div class="padd-box-sm">
+                                <h2>Your message has been sent.</h2>
+                                <p>Thank you for reaching out!</p>
+                            </div>
                         </div>
                     </div>
                     <!-- .padd-box -->

--- a/php/mailsender.php
+++ b/php/mailsender.php
@@ -1,6 +1,18 @@
 <?php
 
-	$emailTo = "a.laurence@celestial.tokyo"; // Enter your email for feedbacks here 
+// Return JSON responses
+header('Content-Type: application/json');
+
+        // The destination email is provided via environment variable so that it
+        // is not exposed in the repository.  Set CONTACT_EMAIL in the hosting
+        // environment to the address that should receive contact form
+        // submissions.
+        $emailTo = getenv('CONTACT_EMAIL');
+        if (!$emailTo) {
+                // Abort if the variable is not configured.
+                echo json_encode(false);
+                return;
+        }
 	
 	$headers = "MIME-Version: 1.0\r\n";
 	$headers .= "Content-type: text/html; charset=utf-8\r\n";


### PR DESCRIPTION
## Summary
- keep recipient email private in PHP contact form
- document how to set the recipient email
- validate contact form inputs and show messages
- redirect to success page after sending
- add `message-sent.html` page

## Testing
- `php -l php/mailsender.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f90ed2cac8329a686331f91e09222